### PR TITLE
Fix protocol link in README.md

### DIFF
--- a/adapters/websocket/README.md
+++ b/adapters/websocket/README.md
@@ -1,6 +1,6 @@
 # @loro-extended/adapter-websocket
 
-WebSocket network adapter implementing the [Loro Syncing Protocol](https://loro.dev/docs/protocol) for `@loro-extended/repo`.
+WebSocket network adapter implementing the [Loro Syncing Protocol](https://loro.dev/blog/loro-protocol) for `@loro-extended/repo`.
 
 ## Features
 
@@ -129,7 +129,7 @@ export default app;
 
 ## Protocol
 
-This adapter implements the [Loro Syncing Protocol](https://loro.dev/docs/protocol), which uses binary messages over WebSocket for efficient real-time synchronization.
+This adapter implements the [Loro Syncing Protocol](https://loro.dev/blog/loro-protocol) which uses binary messages over WebSocket for efficient real-time synchronization.
 
 ### Message Types
 


### PR DESCRIPTION
The current link has a 404.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update protocol links in `adapters/websocket/README.md` to point to `loro.dev/blog/loro-protocol`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a49f823e000f296313fbdad5a0bc6f58a8b8986d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->