### PR TITLE
Sample websocket adapter, more generic websocket

### DIFF
--- a/adapters/websocket/src/index.ts
+++ b/adapters/websocket/src/index.ts
@@ -9,6 +9,8 @@
 
 // Client adapter
 export { WsClientNetworkAdapter, type WsClientOptions } from "./client.js"
+// WebSocket interface types
+export type { WebSocketConstructorLike, WebSocketLike } from "./types.js"
 // Connection
 export { WsConnection } from "./connection.js"
 // Handler types

--- a/adapters/websocket/src/types.ts
+++ b/adapters/websocket/src/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Interface representing a WebSocket-like instance.
+ * This interface captures the subset of the WebSocket API used by the WebSocketClientAdapter.
+ */
+export interface WebSocketLike {
+  // Properties
+  readyState: number
+  binaryType: "arraybuffer" | "blob"
+
+  // Methods
+  send(data: string | ArrayBufferLike | Uint8Array): void
+  close(code?: number, reason?: string): void
+  addEventListener(
+    type: "open",
+    listener: (event: Event) => void,
+    options?: boolean | AddEventListenerOptions
+  ): void
+  addEventListener(
+    type: "error",
+    listener: (event: Event) => void,
+    options?: boolean | AddEventListenerOptions
+  ): void
+  addEventListener(
+    type: "close",
+    listener: (event: CloseEvent) => void,
+    options?: boolean | AddEventListenerOptions
+  ): void
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent) => void,
+    options?: boolean | AddEventListenerOptions
+  ): void
+  removeEventListener(
+    type: "open",
+    listener: (event: Event) => void,
+    options?: boolean | EventListenerOptions
+  ): void
+  removeEventListener(
+    type: "error",
+    listener: (event: Event) => void,
+    options?: boolean | EventListenerOptions
+  ): void
+  removeEventListener(
+    type: "close",
+    listener: (event: CloseEvent) => void,
+    options?: boolean | EventListenerOptions
+  ): void
+  removeEventListener(
+    type: "message",
+    listener: (event: MessageEvent) => void,
+    options?: boolean | EventListenerOptions
+  ): void
+}
+
+/**
+ * Interface representing a WebSocket-like constructor.
+ * This interface captures the constructor signature and static constants used by the WebSocketClientAdapter.
+ */
+export interface WebSocketConstructorLike<
+  T extends WebSocketLike = WebSocketLike,
+> {
+  new (url: string): T
+
+  // Static constants for connection state
+  readonly CONNECTING: number
+  readonly OPEN: number
+  readonly CLOSING: number
+  readonly CLOSED: number
+}


### PR DESCRIPTION
This enhancement would allow the use of _not strictly_ websockets, e.g. [socket.io](https://socket.io/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Generalizes the WebSocket client to accept custom WebSocket-like implementations and exports new interface types.
> 
> - **Client adapter (`adapters/websocket/src/client.ts`)**:
>   - Make `WsClientNetworkAdapter` and `WsClientOptions` generic over `TWebSocket extends WebSocketLike`.
>   - Accept custom `WebSocket` via `WebSocketConstructorLike<TWebSocket>` and use its static ready-state constants instead of global `WebSocket`.
>   - Update checks for `readyState` and keepalive to use `this.WebSocketImpl.OPEN`.
> - **Types (`adapters/websocket/src/types.ts`)**:
>   - Add `WebSocketLike` and `WebSocketConstructorLike` interfaces capturing the subset of APIs used.
> - **Exports (`adapters/websocket/src/index.ts`)**:
>   - Re-export `WebSocketConstructorLike` and `WebSocketLike`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d544248557c0ededad7bc83935425012c4b6be5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->