### PR TITLE
fix: add default condition to package exports

### DIFF
--- a/packages/asks/package.json
+++ b/packages/asks/package.json
@@ -14,8 +14,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     },
     "./src": "./src/index.ts",
     "./src/*": "./src/*"

--- a/packages/change/package.json
+++ b/packages/change/package.json
@@ -14,8 +14,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     },
     "./src": "./src/index.ts",
     "./src/*": "./src/*"

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -14,8 +14,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     },
     "./src": "./src/index.ts",
     "./src/*": "./src/*"

--- a/packages/hooks-core/package.json
+++ b/packages/hooks-core/package.json
@@ -14,8 +14,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     },
     "./src": "./src/index.ts",
     "./src/*": "./src/*"

--- a/packages/lea/package.json
+++ b/packages/lea/package.json
@@ -14,8 +14,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     },
     "./src": "./src/index.ts",
     "./src/*": "./src/*"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -14,8 +14,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     },
     "./src": "./src/index.ts",
     "./src/*": "./src/*"

--- a/packages/repo/package.json
+++ b/packages/repo/package.json
@@ -14,8 +14,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "default": "./dist/index.js"
     },
     "./src": "./src/index.ts",
     "./src/*": "./src/*"


### PR DESCRIPTION
## Summary

Adds the `default` export condition to all `@loro-extended/*` packages to ensure compatibility with CommonJS module loaders and tools like tsx.

## Problem

Without the `default` condition, imports from CommonJS contexts fail with:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined
```

This occurs when:
- Using `require()` from CommonJS
- Using tsx with `-e` flag (which converts to CJS internally)
- Other tools that attempt CJS resolution

## Solution

Add `"default": "./dist/index.js"` to the exports field, following Node.js best practices:

```diff
  "exports": {
    ".": {
+     "types": "./dist/index.d.ts",
      "import": "./dist/index.js",
-     "types": "./dist/index.d.ts"
+     "default": "./dist/index.js"
    }
  }
```

The `default` condition serves as a fallback when no other condition matches.

## Packages Updated

- `@loro-extended/asks`
- `@loro-extended/change`
- `@loro-extended/hono`
- `@loro-extended/hooks-core`
- `@loro-extended/lea`
- `@loro-extended/react`
- `@loro-extended/repo`

## Testing

Verified that `npx tsx` can now successfully import from all packages.

## References

- [Node.js Package Entry Points](https://nodejs.org/api/packages.html#conditional-exports)
- [TypeScript Module Resolution](https://www.typescriptlang.org/docs/handbook/modules/theory.html#module-resolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)