### PR TITLE
feat(repo): add unload(docId) — evict from memory, retain storage

### DIFF
--- a/.changeset/repo-unload-primitive.md
+++ b/.changeset/repo-unload-primitive.md
@@ -1,0 +1,40 @@
+---
+"@loro-extended/repo": minor
+---
+
+### New API: `Repo.unload(docId)` — evict a document from memory while retaining storage
+
+Adds an eviction primitive that frees the in-memory (wasm-backed) `LoroDoc` and
+its per-doc bookkeeping without deleting anything.
+
+Unlike `Repo.delete(docId)`, `unload`:
+
+- sends **no** `channel/delete-request` to any peer, and
+- does **not** touch storage.
+
+Persisted chunks survive, so calling `repo.get(docId)` again rehydrates the
+document from the storage adapter via storage-first sync. Peer `subscriptions`
+are intentionally left intact (stale-but-harmless; the re-get's sync-request
+re-establishes them).
+
+Use this for resource management — LRU caches, idle sweeps — where you want to
+release memory without signalling that the document is gone (it isn't; it lives
+on disk and on other replicas).
+
+```typescript
+await repo.unload("my-doc") // frees memory, keeps storage
+const doc = repo.get("my-doc", DocSchema) // rehydrates from disk
+await sync(doc).waitForSync({ kind: "storage" }) // await storage consult
+```
+
+To await rehydration after a re-get, use the existing
+`sync(doc).waitForSync({ kind: "storage" })`, which resolves once storage has
+been consulted (whether or not it held data) — no new wait API is needed.
+
+**Caveat:** unloading a document with in-flight storage/network requests orphans
+those queued requests; a late storage sync-response then re-creates the doc via
+the snapshot path. Unload only quiescent documents.
+
+Also adds `Synchronizer.unloadDocument(docId)` (dispatches the new
+`synchronizer/doc-unload` message and clears the doc's `readyStates` entry and
+namespaced ephemeral stores) and `EphemeralStoreManager.removeDoc(docId)`.

--- a/packages/repo/src/repo.ts
+++ b/packages/repo/src/repo.ts
@@ -261,6 +261,34 @@ export class Repo {
   }
 
   /**
+   * Unloads a document from memory while retaining its persisted storage.
+   *
+   * This evicts the in-memory document — freeing the wasm-backed LoroDoc and
+   * its per-doc bookkeeping — but, unlike {@link delete}, sends NO
+   * `channel/delete-request` to any peer and does NOT touch storage. Persisted
+   * chunks survive, so calling {@link get} again rehydrates the document from
+   * the storage adapter via storage-first sync.
+   *
+   * Use this for resource management — LRU caches, idle sweeps — where you want
+   * to release memory without signalling that the document is gone (it isn't;
+   * it lives on disk and on other replicas).
+   *
+   * To await rehydration after a re-get, use
+   * `sync(doc).waitForSync({ kind: "storage" })`, which resolves once storage
+   * has been consulted (whether or not it held data).
+   *
+   * Caveat: unloading a document with in-flight storage/network requests
+   * orphans those queued requests; a late storage sync-response then re-creates
+   * the doc via the snapshot path. Unload only quiescent documents.
+   *
+   * @param docId The ID of the document to unload from memory
+   */
+  async unload(docId: DocId): Promise<void> {
+    this.#docCache.delete(docId)
+    await this.#synchronizer.unloadDocument(docId)
+  }
+
+  /**
    * Disconnects all network adapters and cleans up resources.
    * This should be called when the Repo is no longer needed.
    *

--- a/packages/repo/src/synchronizer-program.ts
+++ b/packages/repo/src/synchronizer-program.ts
@@ -133,6 +133,7 @@ export type SynchronizerMessage =
   | { type: "synchronizer/doc-ensure"; docId: DocId }
   | { type: "synchronizer/local-doc-change"; docId: DocId }
   | { type: "synchronizer/doc-delete"; docId: DocId }
+  | { type: "synchronizer/doc-unload"; docId: DocId }
   | {
       type: "synchronizer/doc-imported"
       docId: DocId

--- a/packages/repo/src/synchronizer.ts
+++ b/packages/repo/src/synchronizer.ts
@@ -964,6 +964,43 @@ export class Synchronizer {
     this.#dispatch({ type: "synchronizer/doc-delete", docId })
   }
 
+  /**
+   * Unload a document from memory while retaining storage.
+   *
+   * Unlike {@link removeDocument}, this sends NO delete-request to any peer and
+   * does NOT touch storage. It removes the in-memory document from the model
+   * (via the `synchronizer/doc-unload` message), then clears the runtime-side
+   * per-doc bookkeeping the model can't reach: the `readyStates` entry and the
+   * doc's namespaced ephemeral stores. Persisted chunks survive, so a later
+   * `repo.get(docId)` runs a fresh doc-ensure → sync-request cycle and
+   * storage-first sync rehydrates the doc from disk.
+   *
+   * Peer `subscriptions` entries are intentionally left intact (stale but
+   * harmless; the re-get's sync-request re-establishes them).
+   *
+   * Use this for resource management (LRU eviction, idle sweeps), not deletion.
+   */
+  public async unloadDocument(docId: DocId): Promise<void> {
+    const docState = this.model.documents.get(docId)
+
+    if (!docState) {
+      this.logger.debug("unloadDocument: document {docId} not found", { docId })
+      return
+    }
+
+    // Removes the doc from the model. No delete-request, storage untouched.
+    this.#dispatch({ type: "synchronizer/doc-unload", docId })
+
+    // The doc-unload dispatch removes the doc from model.documents, which the
+    // work-queue's #emitReadyStateChanges already collapses to an empty
+    // readyStates entry at quiescence. Delete the entry outright so the doc
+    // leaves no per-doc bookkeeping behind.
+    this.readyStates.delete(docId)
+
+    // Ephemeral stores are tied to the in-memory doc lifecycle; release them.
+    this.#ephemeralManager.removeDoc(docId)
+  }
+
   public async reset() {
     // TODO(duane): Should we stop/start the heartbeat? It doesn't seem to add value to do so. Maybe we should have a stop/start function on Synchronizer?
 

--- a/packages/repo/src/synchronizer/ephemeral-store-manager.ts
+++ b/packages/repo/src/synchronizer/ephemeral-store-manager.ts
@@ -266,6 +266,32 @@ export class EphemeralStoreManager {
   }
 
   /**
+   * Remove all namespaced stores for a document and unsubscribe from each.
+   *
+   * Used when a document is unloaded from memory: the ephemeral stores belong
+   * to the in-memory doc lifecycle, so they must be released too. Re-creating
+   * the doc via `get()` lazily re-creates its stores on first ephemeral access.
+   *
+   * @param docId - The document ID whose stores should be released
+   */
+  removeDoc(docId: DocId): void {
+    const namespaceStores = this.stores.get(docId)
+    if (!namespaceStores) {
+      return
+    }
+
+    for (const store of namespaceStores.values()) {
+      const unsub = this.#subscriptions.get(store)
+      if (unsub) {
+        unsub()
+        this.#subscriptions.delete(store)
+      }
+    }
+
+    this.stores.delete(docId)
+  }
+
+  /**
    * Unsubscribe from all stores and clean up.
    */
   unsubscribeAll(): void {

--- a/packages/repo/src/synchronizer/sync/handle-doc-unload.test.ts
+++ b/packages/repo/src/synchronizer/sync/handle-doc-unload.test.ts
@@ -1,0 +1,129 @@
+import type { PeerID } from "loro-crdt"
+import { beforeEach, describe, expect, it } from "vitest"
+import { createPermissions } from "../../permissions.js"
+import {
+  createSynchronizerUpdate,
+  init as programInit,
+  type SynchronizerMessage,
+} from "../../synchronizer-program.js"
+import { createDocState, createEstablishedChannel } from "../test-utils.js"
+
+describe("handle-doc-unload", () => {
+  let update: ReturnType<typeof createSynchronizerUpdate>
+
+  beforeEach(() => {
+    update = createSynchronizerUpdate({
+      permissions: createPermissions(),
+    })
+  })
+
+  it("should remove the document from the model", () => {
+    const [initialModel] = programInit({
+      peerId: "test-id" as PeerID,
+      name: "test",
+      type: "user",
+    })
+
+    const docState = createDocState({ docId: "test-doc" })
+    initialModel.documents.set("test-doc", docState)
+    expect(initialModel.documents.has("test-doc")).toBe(true)
+
+    const message: SynchronizerMessage = {
+      type: "synchronizer/doc-unload",
+      docId: "test-doc",
+    }
+
+    const [newModel, command] = update(message, initialModel)
+
+    expect(newModel.documents.has("test-doc")).toBe(false)
+    expect(command).toBeUndefined()
+  })
+
+  it("should NOT send a delete-request even when a peer is subscribed", () => {
+    // This is the load-bearing difference from doc-delete: doc-delete fans out a
+    // channel/delete-request to every subscribed peer; doc-unload must send
+    // nothing (storage and peers are untouched — it is a memory eviction).
+    const peerId = "test-peer-id" as PeerID
+    const channel = createEstablishedChannel(peerId, { channelId: 1 })
+    const docId = "test-doc"
+
+    const [initialModel] = programInit({
+      peerId: "test-id" as PeerID,
+      name: "test",
+      type: "user",
+    })
+    initialModel.channels.set(channel.channelId, channel)
+
+    const docState = createDocState({ docId })
+    initialModel.documents.set(docId, docState)
+
+    // Peer is subscribed to the doc — doc-delete would notify it.
+    initialModel.peers.set(peerId, {
+      identity: { peerId, name: "test-peer", type: "user" },
+      docSyncStates: new Map(),
+      subscriptions: new Set([docId]),
+      channels: new Set([channel.channelId]),
+    })
+
+    const message: SynchronizerMessage = {
+      type: "synchronizer/doc-unload",
+      docId,
+    }
+
+    const [newModel, command] = update(message, initialModel)
+
+    expect(newModel.documents.has(docId)).toBe(false)
+    expect(command).toBeUndefined()
+  })
+
+  it("should leave peer subscriptions intact (stale-but-harmless)", () => {
+    const peerId = "test-peer-id" as PeerID
+    const channel = createEstablishedChannel(peerId, { channelId: 1 })
+    const docId = "test-doc"
+
+    const [initialModel] = programInit({
+      peerId: "test-id" as PeerID,
+      name: "test",
+      type: "user",
+    })
+    initialModel.channels.set(channel.channelId, channel)
+
+    const docState = createDocState({ docId })
+    initialModel.documents.set(docId, docState)
+
+    initialModel.peers.set(peerId, {
+      identity: { peerId, name: "test-peer", type: "user" },
+      docSyncStates: new Map(),
+      subscriptions: new Set([docId]),
+      channels: new Set([channel.channelId]),
+    })
+
+    const message: SynchronizerMessage = {
+      type: "synchronizer/doc-unload",
+      docId,
+    }
+
+    const [newModel] = update(message, initialModel)
+
+    // Subscription is intentionally NOT pruned: a later re-get re-establishes it.
+    expect(newModel.peers.get(peerId)?.subscriptions.has(docId)).toBe(true)
+  })
+
+  it("should log a warning when the document doesn't exist (idempotent)", () => {
+    const [initialModel] = programInit({
+      peerId: "test-id" as PeerID,
+      name: "test",
+      type: "user",
+    })
+
+    const message: SynchronizerMessage = {
+      type: "synchronizer/doc-unload",
+      docId: "nonexistent-doc",
+    }
+
+    const [newModel, command] = update(message, initialModel)
+
+    expect(newModel).toBe(initialModel)
+    expect(command).toBeUndefined()
+  })
+})

--- a/packages/repo/src/synchronizer/sync/handle-doc-unload.ts
+++ b/packages/repo/src/synchronizer/sync/handle-doc-unload.ts
@@ -1,0 +1,71 @@
+/**
+ * Handle doc-unload - Evict a document from memory while retaining storage.
+ *
+ * Unlike {@link handleDocDelete}, this is a *pure memory eviction*: it removes
+ * the document from the synchronizer's model so it stops being tracked and
+ * synchronized, but it sends NO `channel/delete-request` to any peer and does
+ * NOT touch storage. Persisted chunks survive; a later `repo.get(docId)` runs a
+ * fresh doc-ensure → sync-request cycle and storage-first sync rehydrates the
+ * doc from disk.
+ *
+ * ## Why unload exists separately from delete
+ *
+ * `delete` is a *user intent* ("get rid of this document"): it fans a
+ * delete-request out to subscribed peers. `unload` is a *resource-management
+ * action* ("I don't need this in memory right now"): LRU caches and idle sweeps
+ * want to free wasm memory without telling anyone the doc is gone, because it
+ * isn't — it's still on disk and on other replicas.
+ *
+ * ## What gets evicted (by the handler)
+ *
+ * - The document state (LoroDoc instance) from `model.documents`.
+ *
+ * ## What the runtime additionally clears (in Synchronizer.unloadDocument)
+ *
+ * - The doc's `readyStates` entry.
+ * - The doc's `EphemeralStoreManager` namespaced stores.
+ *
+ * ## What is intentionally left intact
+ *
+ * - Persisted data in storage adapters (the whole point — retained for re-get).
+ * - Peer `subscriptions` entries. These are stale-but-harmless: a re-`get()`
+ *   triggers doc-ensure → sync-request, and storage-first sync rehydrates. We
+ *   do not prune them so unload stays a cheap, local-only operation.
+ *
+ * ## Caveat: in-flight storage/network requests
+ *
+ * Unloading a doc that has in-flight `pendingStorageChannels` /
+ * `pendingNetworkRequests` orphans those queued requests. A late storage
+ * sync-response then finds no docState and the snapshot path re-creates it
+ * (see handle-sync-response.ts). Callers should unload only *quiescent* docs;
+ * the doc still recovers correctly on the next `get()`.
+ *
+ * @see handle-doc-delete.ts - Distributed deletion (fans out delete-request)
+ * @see handle-doc-ensure.ts - Create/load document
+ */
+
+import type { Logger } from "@logtape/logtape"
+import type { Command, SynchronizerModel } from "../../synchronizer-program.js"
+import type { DocId } from "../../types.js"
+
+export function handleDocUnload(
+  msg: { type: "synchronizer/doc-unload"; docId: DocId },
+  model: SynchronizerModel,
+  logger: Logger,
+): Command | undefined {
+  const { docId } = msg
+
+  const docState = model.documents.get(docId)
+
+  // If document doesn't exist, log warning but don't fail (idempotent)
+  if (!docState) {
+    logger.warn("doc-unload: unable to find doc-state {docId}", { docId })
+    return
+  }
+
+  // Remove the in-memory document from the model. No delete-request is sent to
+  // any peer and storage is untouched: this is an eviction, not a deletion.
+  model.documents.delete(docId)
+
+  return undefined
+}

--- a/packages/repo/src/synchronizer/synchronizer-dispatcher.ts
+++ b/packages/repo/src/synchronizer/synchronizer-dispatcher.ts
@@ -14,6 +14,7 @@ import { handleEstablishChannel } from "./connection/handle-establish-channel.js
 import { handleDocDelete } from "./sync/handle-doc-delete.js"
 import { handleDocEnsure } from "./sync/handle-doc-ensure.js"
 import { handleDocImported } from "./sync/handle-doc-imported.js"
+import { handleDocUnload } from "./sync/handle-doc-unload.js"
 import { handleLocalDocChange } from "./sync/handle-local-doc-change.js"
 
 export function synchronizerDispatcher(
@@ -107,6 +108,9 @@ export function synchronizerDispatcher(
 
     case "synchronizer/doc-delete":
       return handleDocDelete(msg, model, logger)
+
+    case "synchronizer/doc-unload":
+      return handleDocUnload(msg, model, logger)
 
     case "synchronizer/channel-receive-message":
       // Channel messages are routed through the channel dispatcher

--- a/packages/repo/src/tests/unload.test.ts
+++ b/packages/repo/src/tests/unload.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Integration tests for Repo.unload(docId).
+ *
+ * unload evicts a document from memory while retaining storage and sending NO
+ * channel messages, unlike delete (which fans a delete-request out to peers).
+ * These tests pin the four behaviors the durability work depends on:
+ *
+ *  1. unload → re-get rehydrates from the storage adapter.
+ *  2. unload sends NO channel/delete-request to peers (contrast with delete).
+ *  3. inbound sync for an unloaded doc re-creates docState.
+ *  4. unload while a storage consult is in flight: recovers on re-get
+ *     (the documented orphaned-pending caveat).
+ */
+
+import { change, Shape } from "@loro-extended/change"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { Bridge, BridgeAdapter } from "../adapter/bridge-adapter.js"
+import { Repo } from "../repo.js"
+import { InMemoryStorageAdapter } from "../storage/in-memory-storage-adapter.js"
+import { sync } from "../sync.js"
+
+const StorageDocSchema = Shape.doc({
+  data: Shape.struct({
+    title: Shape.plain.string(),
+  }),
+})
+
+describe("Repo.unload", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("rehydrates from the storage adapter on re-get", async () => {
+    const storage = new InMemoryStorageAdapter()
+    const repo = new Repo({
+      identity: { name: "repo", type: "user" },
+      adapters: [storage],
+    })
+    await vi.runAllTimersAsync()
+
+    const docId = "unload-rehydrate"
+    const doc = repo.get(docId, StorageDocSchema)
+    change(doc, draft => {
+      draft.data.title.set("persisted")
+    })
+
+    // Ensure the content reached the storage adapter before evicting.
+    await repo.flush()
+    await vi.runAllTimersAsync()
+    expect(repo.has(docId)).toBe(true)
+
+    // Evict from memory. Storage is retained.
+    await repo.unload(docId)
+    expect(repo.has(docId)).toBe(false)
+    // Storage chunks survive the unload.
+    expect(storage.getStorage().size).toBeGreaterThan(0)
+
+    // Re-get and await storage-first sync — content comes back from disk.
+    const doc2 = repo.get(docId, StorageDocSchema)
+    await sync(doc2).waitForSync({ kind: "storage", timeout: 0 })
+    await vi.runAllTimersAsync()
+
+    expect(doc2.toJSON().data.title).toBe("persisted")
+  }, 1000)
+
+  it("sends NO delete-request to a connected peer (contrast with delete)", async () => {
+    const bridge = new Bridge()
+    const repoA = new Repo({
+      identity: { name: "repoA", type: "user" },
+      adapters: [new BridgeAdapter({ bridge, adapterType: "a" })],
+    })
+    const repoB = new Repo({
+      identity: { name: "repoB", type: "user" },
+      adapters: [new BridgeAdapter({ bridge, adapterType: "b" })],
+    })
+
+    const docId = "unload-no-delete"
+    const docA = repoA.get(docId, StorageDocSchema)
+    change(docA, draft => {
+      draft.data.title.set("shared")
+    })
+
+    // Let B sync the doc from A so B is subscribed.
+    const docB = repoB.get(docId, StorageDocSchema)
+    await sync(docB).waitForSync({ timeout: 0 })
+    await vi.runAllTimersAsync()
+    expect(docB.toJSON().data.title).toBe("shared")
+    expect(repoB.has(docId)).toBe(true)
+
+    // Unload on A: B must NOT be told the doc is gone.
+    await repoA.unload(docId)
+    await vi.runAllTimersAsync()
+
+    // B still holds the doc — no delete-request arrived to evict it.
+    expect(repoB.has(docId)).toBe(true)
+    expect(docB.toJSON().data.title).toBe("shared")
+  }, 1000)
+
+  it("re-creates docState from an inbound sync after unload", async () => {
+    const bridge = new Bridge()
+    const repoA = new Repo({
+      identity: { name: "repoA", type: "user" },
+      adapters: [new BridgeAdapter({ bridge, adapterType: "a" })],
+    })
+    const repoB = new Repo({
+      identity: { name: "repoB", type: "user" },
+      adapters: [new BridgeAdapter({ bridge, adapterType: "b" })],
+    })
+
+    const docId = "unload-inbound-recreate"
+    const docA = repoA.get(docId, StorageDocSchema)
+    change(docA, draft => {
+      draft.data.title.set("v1")
+    })
+
+    const docB = repoB.get(docId, StorageDocSchema)
+    await sync(docB).waitForSync({ timeout: 0 })
+    await vi.runAllTimersAsync()
+
+    // Unload on B, then have A make a change. B's re-get + sync should pull it.
+    await repoB.unload(docId)
+    expect(repoB.has(docId)).toBe(false)
+
+    change(docA, draft => {
+      draft.data.title.set("v2")
+    })
+    await vi.runAllTimersAsync()
+
+    // Re-get on B recreates docState and re-syncs from A.
+    const docB2 = repoB.get(docId, StorageDocSchema)
+    await sync(docB2).waitForSync({ timeout: 0 })
+    await vi.runAllTimersAsync()
+
+    expect(repoB.has(docId)).toBe(true)
+    expect(docB2.toJSON().data.title).toBe("v2")
+  }, 1000)
+
+  it("recovers on re-get when unloaded mid storage consult (orphaned-pending caveat)", async () => {
+    const storage = new InMemoryStorageAdapter()
+    const repo = new Repo({
+      identity: { name: "repo", type: "user" },
+      adapters: [storage],
+    })
+    await vi.runAllTimersAsync()
+
+    const docId = "unload-mid-consult"
+    const doc = repo.get(docId, StorageDocSchema)
+    change(doc, draft => {
+      draft.data.title.set("durable")
+    })
+    await repo.flush()
+    await vi.runAllTimersAsync()
+
+    // Evict, then re-get WITHOUT awaiting the storage consult, and unload again
+    // immediately — the second unload orphans the in-flight storage consult
+    // queued by the re-get (the documented caveat). A late storage sync-response
+    // may then re-create docState via the snapshot path; whether or not it has
+    // by this point is a race, so we don't assert on `has` here.
+    await repo.unload(docId)
+    repo.get(docId, StorageDocSchema)
+    await repo.unload(docId)
+
+    // The point of the caveat: regardless of the orphaned consult, the doc
+    // recovers correctly on re-get because the durable chunks are still on disk.
+    const docFinal = repo.get(docId, StorageDocSchema)
+    await vi.runAllTimersAsync()
+    await repo.flush()
+    await vi.runAllTimersAsync()
+
+    expect(docFinal.toJSON().data.title).toBe("durable")
+  }, 1000)
+})


### PR DESCRIPTION
## What

Adds `Repo.unload(docId)`: an eviction primitive that frees the in-memory
(wasm-backed) `LoroDoc` and its per-doc bookkeeping **without** sending any
channel message or touching storage. A later `repo.get(docId)` rehydrates the
document from the storage adapter via storage-first sync.

This is distinct from `Repo.delete(docId)`, which fans a `channel/delete-request`
out to every subscribed peer. `unload` is for *resource management* (LRU caches,
idle sweeps) where you want to release memory without signalling that the
document is gone — because it isn't; it lives on disk and on other replicas.

## Why

Downstream (Shipyard), plan/canvas CRDT docs are evicted from memory under LRU
pressure and idle sweeps. Today those sites call `delete`, whose eviction
*safety* rests on three accidents that all happen to make the storage delete a
no-op:

1. **Browser IndexedDB**: `handleDeleteRequest` removes only the exact `[docId]`
   key, but chunks live at `[docId, "update", ts]` keys — so the delete silently
   no-ops and the IDB replica survives. Only the in-memory doc is destroyed.
2. **Daemon FileStorageAdapter**: `remove([docId])` calls `unlink()` on a
   *directory* → `EISDIR`, swallowed by `catch {}`. Disk chunks survive.
3. Peer-gate `deletion: () => false`.

If the storage layer's delete is ever "fixed" to a range delete, both the
browser LRU and the daemon idle sweep would start destroying real replicas.
`unload` removes the dependence on those accidents: it is an explicit,
memory-only eviction that retains storage by construction.

> **Out of scope (documented, not changed here):** the storage delete /
> key-format mismatch above. `handleDeleteRequest` in the storage adapters
> removes only the exact `[docId]` key while chunks live at `[docId, "update",
> ts]` keys, so `delete` currently no-ops on stored chunks. That is a known
> accident; this PR deliberately does **not** change delete semantics.

## API shape

```typescript
await repo.unload("my-doc")              // frees memory, keeps storage
const doc = repo.get("my-doc", DocSchema) // rehydrates from disk
await sync(doc).waitForSync({ kind: "storage" }) // await storage consult
```

- `Repo.unload(docId)` — deletes the `#docCache` entry, calls
  `Synchronizer.unloadDocument(docId)`.
- `Synchronizer.unloadDocument(docId)` — dispatches the new
  `synchronizer/doc-unload` message (added to the `SynchronizerMessage` union;
  the dispatcher's exhaustive switch forces the new case), then clears the doc's
  `readyStates` entry and its namespaced ephemeral stores.
- `handleDocUnload` — mirrors `handleDocDelete`'s model removal but returns
  **no** `cmd/send-message` (pure TEA model update returning no commands).
- `EphemeralStoreManager.removeDoc(docId)` — unsubscribes + releases a doc's
  namespaced ephemeral stores.
- Peer `subscriptions` entries are intentionally **left intact** (stale but
  harmless; the re-get's sync-request re-establishes them and storage-first sync
  rehydrates).

### No new wait API

The spec asked for a `Repo.waitForReady(docId)` *only if* the existing
Handle/`waitForSync` surface didn't already cover "storage consult finished for
a doc with no data." It does: `sync(doc).waitForSync({ kind: "storage" })`
resolves on both `synced` (data) **and** `absent` (storage confirmed no data) —
see `SyncRefImpl#createSyncPredicate` (`status === "synced" || status ===
"absent"`). So no redundant Repo-level API was added; callers already hold the
`Doc` from `repo.get()`.

## Caveat (documented in code + tested)

Unloading a doc with in-flight `pendingStorageChannels` / `pendingNetworkRequests`
orphans those queued requests — a late storage sync-response finds no docState
and the snapshot path (`handle-sync-response.ts`) re-creates it. Callers should
unload only **quiescent** docs; the doc still recovers correctly on the next
`get()`. The `unload-mid-consult` test pins this recovery behavior.

## Tests

All in `packages/repo`, green (`pnpm --filter @loro-extended/repo verify`:
format + types + 735/735 logic tests).

**`handle-doc-unload.test.ts`** (TEA purity):
- removes the doc from the model, returns no command
- **sends no `channel/delete-request` even when a peer is subscribed** (the
  load-bearing contrast with `doc-delete`)
- leaves peer subscriptions intact
- idempotent / warns when the doc doesn't exist

**`tests/unload.test.ts`** (integration, in-memory storage adapter + Bridge):
- unload → re-`get()` rehydrates from the storage adapter
- unload sends no delete-request to a connected peer (B keeps its copy)
- inbound sync after unload re-creates docState
- recovery on re-get when unloaded mid storage consult (the orphaned-pending
  caveat)

## Notes

- This repo has **no GitHub Actions CI**; the gate is local `verify`. The
  `@loro-extended/lens` package has 33 pre-existing failing tests on `main`
  (verified by stashing this branch's changes and re-running) — unrelated to
  this PR, which is isolated to `packages/repo`.
- Includes a changeset (`@loro-extended/repo` minor bump; additive API).
  Publishing `6.0.0-beta.1` is intentionally left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)